### PR TITLE
Avoid truncated labels in main window

### DIFF
--- a/src-bmGuiBase/BmMenuControl.cpp
+++ b/src-bmGuiBase/BmMenuControl.cpp
@@ -42,7 +42,7 @@ BmMenuControl::BmMenuControl( const char* label, BMenu* menu, float weight,
 		SetDivider( (label ? labelWidth + 5 : 2));
 	float minHeight = mMenuBar->Frame().Height()+6;
 	if (fitText) {
-		float fixedWidth = StringWidth( fitText)+Divider()+27;
+		float fixedWidth = StringWidth( fitText)+Divider()+40;
 		ct_mpm = minimax( int(fixedWidth), int(minHeight), 
 								int(fixedWidth), int(minHeight));
 	} else {


### PR DESCRIPTION
Adding a few more magic pixels...
Still remaining: the truncated From/To labels in the new mail window.
No idea about those...