### PR TITLE
Fix missing headers while retrieving emails from iCloud IMAP server

### DIFF
--- a/build-jam/BuildSettings
+++ b/build-jam/BuildSettings
@@ -98,8 +98,8 @@ rule SetUpSubDirBuildSettings {
 		OPTIMIZE = 0 ;
 		STRIP_APPS = 0 ;
 		DEFINES += DEBUG=$(DEBUG) BM_REF_DEBUGGING ;
-		CCFLAGS += -g ;
-		C++FLAGS += -g -fno-inline ;
+		CCFLAGS += -gdwarf-3 ;
+		C++FLAGS += -gdwarf-3 -fno-inline ;
 		LINKFLAGS += -g ;
 		DISTRO_DIR			= [ FDirName $(TOP) generated distro-debug-$(PLATFORM) ] ;
 		OBJECTS_DIR			= [ FDirName $(TOP) generated objects-debug-$(PLATFORM) ] ;

--- a/build-jam/BuildSettings
+++ b/build-jam/BuildSettings
@@ -98,8 +98,8 @@ rule SetUpSubDirBuildSettings {
 		OPTIMIZE = 0 ;
 		STRIP_APPS = 0 ;
 		DEFINES += DEBUG=$(DEBUG) BM_REF_DEBUGGING ;
-		CCFLAGS += -gdwarf-3 ;
-		C++FLAGS += -gdwarf-3 -fno-inline ;
+		CCFLAGS += -g ;
+		C++FLAGS += -g -fno-inline ;
 		LINKFLAGS += -g ;
 		DISTRO_DIR			= [ FDirName $(TOP) generated distro-debug-$(PLATFORM) ] ;
 		OBJECTS_DIR			= [ FDirName $(TOP) generated objects-debug-$(PLATFORM) ] ;

--- a/src-bmDaemon/BmImap.cpp
+++ b/src-bmDaemon/BmImap.cpp
@@ -792,7 +792,9 @@ void BmImap::StateRetrieve()
 		// fetch current mail
 		BmString serverUID = LocalUidToServerUid(mMsgUIDs[i]);
 // TODO: May also add more stuff to FETCH, like "flags"
-		cmd = BmString("UID FETCH ") << serverUID << " rfc822";
+		// cmd = BmString("UID FETCH ") << serverUID << " rfc822";
+		// cmd = BmString("UID FETCH ") << serverUID << " full";
+		cmd = BmString("UID FETCH ") << serverUID << " body[]";
 		SendCommand( cmd);
 		time_t before = time(NULL);
 		if (!CheckForPositiveAnswer( mNewMsgSizes[mCurrMailNr-1], false, true))

--- a/src-bmDaemon/BmImap.cpp
+++ b/src-bmDaemon/BmImap.cpp
@@ -792,8 +792,6 @@ void BmImap::StateRetrieve()
 		// fetch current mail
 		BmString serverUID = LocalUidToServerUid(mMsgUIDs[i]);
 // TODO: May also add more stuff to FETCH, like "flags"
-		// cmd = BmString("UID FETCH ") << serverUID << " rfc822";
-		// cmd = BmString("UID FETCH ") << serverUID << " full";
 		cmd = BmString("UID FETCH ") << serverUID << " body[]";
 		SendCommand( cmd);
 		time_t before = time(NULL);


### PR DESCRIPTION
Beam used the following IMAP command to retrieve the emails from the mailbox:
UID FETCH xxx rfc822
This command returns nothing in iCloud and prevents Beam from populating the mail list. Changing the command to:
UID FETCH xxx body[]
makes iCloud respond correctly with everything needed to populate the list and the email content. It seems safe to make the switch also with other mail providers.