### PR TITLE
keep time_t in BMessage as int32 for compatibility

### DIFF
--- a/src-bmMailKit/BmMailFolder.cpp
+++ b/src-bmMailKit/BmMailFolder.cpp
@@ -111,7 +111,11 @@ BmMailFolder::BmMailFolder( BMessage* archive, BmMailFolderList* model,
 			// [possibly] new device-number).
 			mEntryRef.device = ThePrefs->MailboxVolume.Device();
 		mNodeRef.device = mEntryRef.device;
-		mLastModified = FindMsgInt64( archive, MSG_LASTMODIFIED);
+#ifdef __x86_64__
+		mLastModified = static_cast<int64>(FindMsgInt32( archive, MSG_LASTMODIFIED));
+#else
+		mLastModified = FindMsgInt32( archive, MSG_LASTMODIFIED);
+#endif
 		Key( BM_REFKEY( mNodeRef));
 		mName = mEntryRef.name;
 		if (version > 1)
@@ -169,7 +173,11 @@ status_t BmMailFolder::Archive( BMessage* archive, bool deep) const {
 	status_t ret = inherited::Archive( archive, deep)
 		|| archive->AddRef( MSG_ENTRYREF, &mEntryRef)
 		|| archive->AddInt64( MSG_INODE, mNodeRef.node)
-		|| archive->AddInt64( MSG_LASTMODIFIED, (uint64)time(NULL))
+#ifdef __x86_64__
+		|| archive->AddInt32( MSG_LASTMODIFIED, (int32)time(NULL))
+#else
+		|| archive->AddInt32( MSG_LASTMODIFIED, time(NULL))
+#endif
 							// bump time to the last time folder-cache has 
 							// been written
 		|| archive->AddInt32( MSG_NUMCHILDREN, (int32)size())

--- a/src-bmMailKit/BmMailRef.cpp
+++ b/src-bmMailKit/BmMailRef.cpp
@@ -203,7 +203,11 @@ BmMailRef::BmMailRef( BMessage* archive, node_ref& nref)
 		mStatus = FindMsgString( archive, MSG_STATUS);
 		mSubject = FindMsgString( archive, MSG_SUBJECT);
 		mTo = FindMsgString( archive, MSG_TO);
-		mWhen = FindMsgInt64( archive, MSG_WHEN);
+#ifdef __x86_64__
+		mWhen = static_cast<int64>(FindMsgInt32( archive, MSG_WHEN));
+#else
+		mWhen = FindMsgInt32( archive, MSG_WHEN);
+#endif
 
 		if (version >= 2)
 			mIdentity = FindMsgString( archive, MSG_IDENTITY);
@@ -270,7 +274,11 @@ status_t BmMailRef::Archive( BMessage* archive, bool) const {
 		|| archive->AddString( MSG_SUBJECT, mSubject.String())
 		|| archive->AddString( MSG_TO, mTo.String())
 		|| archive->AddString( MSG_IDENTITY, mIdentity.String())
-		|| archive->AddInt64( MSG_WHEN, mWhen)
+#ifdef __x86_64__
+		|| archive->AddInt32( MSG_WHEN, (int32)mWhen)
+#else
+		|| archive->AddInt32( MSG_WHEN, mWhen)
+#endif
 		|| archive->AddString( MSG_CLASSIFICATION, mClassification.String())
 		|| archive->AddFloat( MSG_RATIO_SPAM, mRatioSpam)
 		|| archive->AddString( MSG_IMAP_UID, mImapUID.String());


### PR DESCRIPTION
a version bump would be needed to switch to int64